### PR TITLE
fix: improve error handling and fonts link

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,9 @@
   window.addEventListener('error', function(e) {
     console.warn('Error capturado:', e.error?.message || 'Error desconocido');
   });
+  window.addEventListener('unhandledrejection', function(e) {
+    console.warn('Promesa rechazada sin capturar:', e.reason?.message || e.reason || 'Error desconocido');
+  });
 
   // ======= Revelado progresivo (IntersectionObserver) con fallback =======
   function initProgressiveReveal() {

--- a/index.html
+++ b/index.html
@@ -332,8 +332,8 @@
       </p>
       <p style="font-size: 1rem; margin-top: 1.5rem; color: var(--muted);">
         Por <strong>Marco</strong> | 
-        <a href="https://github.com/MarcoS9309" target="_blank" style="color: var(--accent); text-decoration: none;">GitHub</a> | 
-        <a href="https://x.com/MarcoS9309" target="_blank" style="color: var(--accent); text-decoration: none;">X (Twitter)</a>
+        <a href="https://github.com/MarcoS9309" target="_blank" rel="noopener noreferrer" style="color: var(--accent); text-decoration: none;">GitHub</a> | 
+        <a href="https://x.com/MarcoS9309" target="_blank" rel="noopener noreferrer" style="color: var(--accent); text-decoration: none;">X (Twitter)</a>
       </p>
       <p style="font-size: 0.9rem; margin-top: 1rem; color: var(--muted); opacity: 0.8;">
         📄 Licenciado bajo 


### PR DESCRIPTION
## Summary
- fix Google Fonts preload URL and noscript fallback so fonts load correctly
- harden error handling by capturing unhandled promise rejections
- add security rel attributes to external links

## Testing
- `node --check app.js`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e76cecf88332a12be381f43c88e3